### PR TITLE
Update Gulp version from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.2.0",
     "del": "^2.2.0",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.2",
     "gulp-babel": "^6.1.1",
     "gulp-eslint": "^1.0.0",
     "gulp-mocha": "^2.1.3"


### PR DESCRIPTION
Use the direct npm URL since the github version seems to be broken.